### PR TITLE
Remove unnecessary site installed check

### DIFF
--- a/pinax_theme_bootstrap/context_processors.py
+++ b/pinax_theme_bootstrap/context_processors.py
@@ -9,11 +9,10 @@ def theme(request):
         "THEME_CONTACT_EMAIL": settings.THEME_CONTACT_EMAIL,
     }
 
-    if Site._meta.installed:
-        site = Site.objects.get_current(request)
-        ctx.update({
-            "SITE_NAME": site.name,
-            "SITE_DOMAIN": site.domain
-        })
+    site = Site.objects.get_current(request)
+    ctx.update({
+        "SITE_NAME": site.name,
+        "SITE_DOMAIN": site.domain
+    })
 
     return ctx


### PR DESCRIPTION
- The Site._meta.installed attribute has been deprecated in Django 3.2. This attribute was used to check if a site had been installed, but it is no longer necessary as Django now automatically checks if a site has been installed.